### PR TITLE
fix: POST requests were not calling the right function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.4.2 (2021-05-21)
+
+* Fix #46: `POST` requests were not calling the right function
+* Updated `express-validator` dependency to v6.11.1
+
 ## 1.4.1 (2021-04-19)
 
 Buttons have batteries! The virtual button will now reflect the current

--- a/lib/ButtonPlatform.js
+++ b/lib/ButtonPlatform.js
@@ -143,7 +143,6 @@ class ButtonPlatform extends HomebridgeLib.Platform {
         return res.status(422).json({ errors: errors.array() });
       } else {
         var event = req.body.event;
-        this.log('Received POST request on %s to trigger a [%s] event for %s', uri, event, accessory.name);
         switch (event) {
           case 'click':
           case 'single-press':
@@ -152,11 +151,11 @@ class ButtonPlatform extends HomebridgeLib.Platform {
             break;
           case 'double-click':
           case 'double-press':
-            accessory.switchService.triggerEvent.triggerEvent(1);
+            accessory.switchService.triggerEvent(1);
             break;
           case 'hold':
           case 'long-press':
-            accessory.switchService.triggerEvent.triggerEvent(2);
+            accessory.switchService.triggerEvent(2);
             break;
         }
         if (req.headers['button-battery-level']) {


### PR DESCRIPTION
Looks like I didn't fully test that `POST` requests were working after the refactoring I did to enable the battery service. Sorry about that! 

Thanks for reporting this, @virginiafarmer!

Fixes 46.

Signed-off-by: Avi Miller <me@dje.li>